### PR TITLE
Add GSP tags (link and createLink) that create short links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target
 *.zip
 plugin.xml
 *sublime*
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ class PostgresSequenceGenerator implements SequenceGenerator {
 }
 ```
 
-Finally, when you have created you custom generator you have to define the `sequenceGenerator` bean in your `resources.groovy` file:
+Finally, when you have created you custom generator you have to define the `urlShortenerSequenceGenerator` bean in your `resources.groovy` file:
 
 ```groovy
-sequenceGenerator(com.example.shortener.PostgresSequenceGenerator) {
+urlShortenerSequenceGenerator(com.example.shortener.PostgresSequenceGenerator) {
     dataSource = ref("dataSource")
 }
 ```
@@ -101,4 +101,5 @@ Collaborations are appreciated :-)
 
 ## Release Notes
 
+* 0.2 - 21/Nov/2014 - *BREAKING CHANGE:* Renamed `sequenceGenerator` bean to `urlShortenerSequenceGenerator`. Added tags `shorter:link` and `shorter:createLink`.
 * 0.1 - 17/Oct/2013 - Initial version of the plugin.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ assert urlShortenerService.getTargetUrl(shortUrl) == "http://kaleidos.net"
 
 The plugin also provides a controller that can be used to redirect to the target url. It is available here [ShortenerController](https://github.com/lmivan/grails-url-shortener/blob/master/grails-app/controllers/net/kaleidos/shortener/ShorternerController.groovy) or you can implement your own custom controller.
 
+### Tag Library
+
+The plugin provides two GSP tags that generate short urls, `link` and `createLink`. They work as the standard Grails `link` and `createLink` but generates short urls.
+
+```javascript
+function copyShortLinkToClipboard() {
+    var url = "${shorter.createLink(controller: 'person', action: 'show', id: person.id, absolute: true)}";
+    window.prompt("${message(code: 'copy.to.clipboard.label', 'Copy to clipboard: Ctrl+C, Enter')}", url);
+}
+```
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -56,14 +56,20 @@ class PostgresSequenceGenerator implements SequenceGenerator {
 }
 ```
 
-Finally, when you have created you custom generator you have to define the `urlShortenerSequenceGenerator` bean in your `resources.groovy` file:
+Finally, when you have created you custom generator you have to define the `sequenceGenerator` bean in your `resources.groovy` file:
 
 ```groovy
-urlShortenerSequenceGenerator(com.example.shortener.PostgresSequenceGenerator) {
+sequenceGenerator(com.example.shortener.PostgresSequenceGenerator) {
     dataSource = ref("dataSource")
 }
 ```
 
+### Sequence Generator Plugin
+
+You can also use the [sequence-generator](http://grails.org/plugin/sequence-generator) plugin to generate sequence numbers for short urls.
+Version 1.1+ of `sequence-generator` is compatible with version 0.2+ of `url-shortener`. Just add the `sequence-generator` plugin to
+your BuildConfig.groovy and you are ready to go.
+You don't have to create a custom generator or configure a sequenceGenerator bean (section above), it done by the `sequence-generator` plugin.
 
 ## Usage
 
@@ -111,5 +117,5 @@ Collaborations are appreciated :-)
 
 ## Release Notes
 
-* 0.2 - 21/Nov/2014 - *BREAKING CHANGE:* Renamed `sequenceGenerator` bean to `urlShortenerSequenceGenerator`. Added tags `shorter:link` and `shorter:createLink`.
+* 0.2 - 21/Nov/2014 - Added GSP tags `shorter:link` and `shorter:createLink`.
 * 0.1 - 17/Oct/2013 - Initial version of the plugin.

--- a/UrlShortenerGrailsPlugin.groovy
+++ b/UrlShortenerGrailsPlugin.groovy
@@ -1,6 +1,6 @@
 class UrlShortenerGrailsPlugin {
     // the plugin version
-    def version = "0.1"
+    def version = "0.2-SNAPSHOT"
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "2.0 > *"
     // the other plugins this plugin depends on

--- a/UrlShortenerGrailsPlugin.groovy
+++ b/UrlShortenerGrailsPlugin.groovy
@@ -8,7 +8,6 @@ class UrlShortenerGrailsPlugin {
     // resources that are excluded from plugin packaging
     def pluginExcludes = [
         "grails-app/views/error.gsp",
-        "grails-app/taglib/**",
         "grails-app/utils/**"
     ]
 
@@ -30,6 +29,8 @@ This is a grails plugin that integrates a custom url shortener inside your Grail
     // Details of company behind the plugin (if there is one)
     def organization = [ name: "Kaleidos", url: "http://kaleidos.net" ]
 
+    def developers = [ [ name: "Goran Ehrsson", email: "goran@technipelago.se" ]]
+
     // Location of the plugin's issue tracker.
     def issueManagement = [ system: "GITHUB", url: "https://github.com/lmivan/grails-url-shortener/issues" ]
 
@@ -49,6 +50,6 @@ This is a grails plugin that integrates a custom url shortener inside your Grail
             log.error "ERROR: UrlShortener short domain not found. The property shortener.shortDomain must be defined in Config.groovy"
         }
 
-        sequenceGenerator(net.kaleidos.shortener.generator.DummySequenceGenerator)
+        urlShortenerSequenceGenerator(net.kaleidos.shortener.generator.DummySequenceGenerator)
     }
 }

--- a/UrlShortenerGrailsPlugin.groovy
+++ b/UrlShortenerGrailsPlugin.groovy
@@ -49,7 +49,5 @@ This is a grails plugin that integrates a custom url shortener inside your Grail
         if (!shortenerConfig.shortDomain) {
             log.error "ERROR: UrlShortener short domain not found. The property shortener.shortDomain must be defined in Config.groovy"
         }
-
-        urlShortenerSequenceGenerator(net.kaleidos.shortener.generator.DummySequenceGenerator)
     }
 }

--- a/UrlShortenerGrailsPlugin.groovy
+++ b/UrlShortenerGrailsPlugin.groovy
@@ -39,13 +39,6 @@ This is a grails plugin that integrates a custom url shortener inside your Grail
 
     def doWithSpring = {
         def shortenerConfig = application.config.shortener
-
-        if (!shortenerConfig.characters) {
-            log.error "ERROR: UrlShortener characters to generate the urls not found. The property shortener.characters must be defined in Config.groovy"
-        }
-        if (!shortenerConfig.minLength) {
-            log.error "ERROR: UrlShortener minimum length not found. The property shortener.minLength must be defined in Config.groovy"
-        }
         if (!shortenerConfig.shortDomain) {
             log.error "ERROR: UrlShortener short domain not found. The property shortener.shortDomain must be defined in Config.groovy"
         }

--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,4 @@
 #Grails Metadata file
 #Tue Oct 08 09:59:54 CEST 2013
-app.grails.version=2.1.5
+app.grails.version=2.4.4
 app.name=url-shortener

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -14,21 +14,16 @@ grails.project.dependency.resolution = {
     }
 
     plugins {
-        build(":tomcat:$grailsVersion",
-              ":release:2.2.0",
-              ":rest-client-builder:1.0.3") {
+        build(":tomcat:7.0.55",
+              ":release:3.0.1") {
             export = false
         }
 
-        test ":spock:0.7", {
+        compile(":guard:2.1.0") {
             export = false
         }
 
-        compile (":guard:1.0.7") {
-            export = false
-        }
-
-        runtime ":hibernate:$grailsVersion", {
+        runtime(":hibernate4:4.3.6.1") {
             export = false
         }
     }

--- a/grails-app/conf/DataSource.groovy
+++ b/grails-app/conf/DataSource.groovy
@@ -1,5 +1,6 @@
 dataSource {
     pooled = true
+    jmxExport = true
     driverClassName = "org.h2.Driver"
     username = "sa"
     password = ""
@@ -7,37 +8,24 @@ dataSource {
 hibernate {
     cache.use_second_level_cache = true
     cache.use_query_cache = false
-    cache.region.factory_class = 'net.sf.ehcache.hibernate.EhCacheRegionFactory'
+//    cache.region.factory_class = 'net.sf.ehcache.hibernate.EhCacheRegionFactory' // Hibernate 3
+    cache.region.factory_class = 'org.hibernate.cache.ehcache.EhCacheRegionFactory' // Hibernate 4
+    singleSession = true // configure OSIV singleSession mode
+    flush.mode = 'manual'
 }
+
 // environment specific settings
 environments {
     development {
         dataSource {
             dbCreate = "create-drop" // one of 'create', 'create-drop', 'update', 'validate', ''
-            url = "jdbc:h2:mem:devDb;MVCC=TRUE;LOCK_TIMEOUT=10000"
+            url = "jdbc:h2:mem:devDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE"
         }
     }
     test {
         dataSource {
             dbCreate = "update"
-            url = "jdbc:h2:mem:testDb;MVCC=TRUE;LOCK_TIMEOUT=10000"
-        }
-    }
-    production {
-        dataSource {
-            dbCreate = "update"
-            url = "jdbc:h2:prodDb;MVCC=TRUE;LOCK_TIMEOUT=10000"
-            pooled = true
-            properties {
-               maxActive = -1
-               minEvictableIdleTimeMillis=1800000
-               timeBetweenEvictionRunsMillis=1800000
-               numTestsPerEvictionRun=3
-               testOnBorrow=true
-               testWhileIdle=true
-               testOnReturn=true
-               validationQuery="SELECT 1"
-            }
+            url = "jdbc:h2:mem:testDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE"
         }
     }
 }

--- a/grails-app/conf/spring/resources.groovy
+++ b/grails-app/conf/spring/resources.groovy
@@ -1,0 +1,3 @@
+beans = {
+    sequenceGenerator(net.kaleidos.shortener.generator.DummySequenceGenerator)
+}

--- a/grails-app/services/net/kaleidos/shortener/UrlShortenerService.groovy
+++ b/grails-app/services/net/kaleidos/shortener/UrlShortenerService.groovy
@@ -6,7 +6,7 @@ class UrlShortenerService {
     static transactional = true
 
     def grailsApplication
-    def urlShortenerSequenceGenerator
+    def sequenceGenerator
 
     List<String> chars
     Integer minLength
@@ -45,7 +45,7 @@ class UrlShortenerService {
             return shortenInstance.shortUrl
         }
 
-        Long nextNumber = urlShortenerSequenceGenerator.getNextNumber()
+        Long nextNumber = sequenceGenerator.getNextNumber()
 
         def shortUrl = this.convert(nextNumber)
         shortenInstance = new ShortenUrl(targetUrl: targetUrl, shortUrl:shortUrl)

--- a/grails-app/services/net/kaleidos/shortener/UrlShortenerService.groovy
+++ b/grails-app/services/net/kaleidos/shortener/UrlShortenerService.groovy
@@ -14,8 +14,21 @@ class UrlShortenerService {
 
     @PostConstruct
     public init() {
+        if (grailsApplication.config.shortener.characters) {
             chars = grailsApplication.config.shortener.characters
+        } else {
+            chars = ['d', '2', 'C', 'S', 'Y', 'v', 'K', '5', 'p', '9', 't', 'k', 'R',
+                          'X', 's', '1', 'N', 'c', 'w', 'F', 'q', 'G', 'T', 'J', 'H', '7',
+                          'h', 'D', 'B', 'Z', 'j', 'n', '4', '6', 'b', 'z', '3', '8', 'V',
+                          'M', 'g', 'm', 'W', 'f', 'y', 'r', '0', 'x', 'P', 'Q']
+        }
+
+        if (grailsApplication.config.shortener.minLength) {
             minLength = grailsApplication.config.shortener.minLength
+        } else {
+            minLength = 4
+        }
+
         shortDomainUrl = grailsApplication.config.shortener.shortDomain
     }
 

--- a/grails-app/services/net/kaleidos/shortener/UrlShortenerService.groovy
+++ b/grails-app/services/net/kaleidos/shortener/UrlShortenerService.groovy
@@ -6,7 +6,7 @@ class UrlShortenerService {
     static transactional = true
 
     def grailsApplication
-    def sequenceGenerator
+    def urlShortenerSequenceGenerator
 
     List<String> chars
     Integer minLength
@@ -14,8 +14,8 @@ class UrlShortenerService {
 
     @PostConstruct
     public init() {
-        chars = grailsApplication.config.shortener.characters
-        minLength = grailsApplication.config.shortener.minLength
+            chars = grailsApplication.config.shortener.characters
+            minLength = grailsApplication.config.shortener.minLength
         shortDomainUrl = grailsApplication.config.shortener.shortDomain
     }
 
@@ -32,7 +32,7 @@ class UrlShortenerService {
             return shortenInstance.shortUrl
         }
 
-        Long nextNumber = sequenceGenerator.getNextNumber()
+        Long nextNumber = urlShortenerSequenceGenerator.getNextNumber()
 
         def shortUrl = this.convert(nextNumber)
         shortenInstance = new ShortenUrl(targetUrl: targetUrl, shortUrl:shortUrl)

--- a/grails-app/taglib/net/kaleidos/shortener/ShortenerTagLib.groovy
+++ b/grails-app/taglib/net/kaleidos/shortener/ShortenerTagLib.groovy
@@ -1,0 +1,36 @@
+package net.kaleidos.shortener
+
+class ShortenerTagLib {
+
+    static namespace = "shorter"
+
+    def urlShortenerService
+
+    private static final List EXCLUDE = ['action', 'controller', 'id', 'params']
+
+    private Map makeUri(Map attrs) {
+        def map = [:]
+        for (entry in attrs) {
+            if (!EXCLUDE.contains(entry.key)) {
+                map[entry.key] = entry.value
+            }
+        }
+        map
+    }
+
+    def link = { Map attrs, Closure body ->
+        def longLink = g.createLink(attrs).toString()
+        def shortLink = urlShortenerService.shortUrlFullDomain(longLink)
+        def tmp = makeUri(attrs)
+        tmp.uri = shortLink
+        out << g.link(tmp, body)
+    }
+
+    def createLink = { Map attrs ->
+        def longLink = g.createLink(attrs).toString()
+        def shortLink = urlShortenerService.shortUrlFullDomain(longLink)
+        def tmp = makeUri(attrs)
+        tmp.uri = shortLink
+        out << g.createLink(tmp)
+    }
+}

--- a/test/integration/net/kaleidos/shortener/ShortenUrlIntegrationSpec.groovy
+++ b/test/integration/net/kaleidos/shortener/ShortenUrlIntegrationSpec.groovy
@@ -1,7 +1,7 @@
 package net.kaleidos.shortener
 
-import grails.plugin.spock.*
-import spock.lang.*
+import grails.test.spock.IntegrationSpec
+import spock.lang.Unroll
 
 class ShortenUrlIntegrationSpec extends IntegrationSpec {
 

--- a/test/integration/net/kaleidos/shortener/ShortenerControllerIntegrationSpec.groovy
+++ b/test/integration/net/kaleidos/shortener/ShortenerControllerIntegrationSpec.groovy
@@ -1,7 +1,6 @@
 package net.kaleidos.shortener
 
-import grails.plugin.spock.*
-import spock.lang.*
+import grails.test.spock.IntegrationSpec
 
 class ShortenerControllerIntegrationSpec extends IntegrationSpec {
 

--- a/test/integration/net/kaleidos/shortener/UrlShortenerServiceIntegrationSpec.groovy
+++ b/test/integration/net/kaleidos/shortener/UrlShortenerServiceIntegrationSpec.groovy
@@ -1,7 +1,7 @@
 package net.kaleidos.shortener
 
-import grails.plugin.spock.*
-import spock.lang.*
+import grails.test.spock.IntegrationSpec
+import spock.lang.Unroll
 
 class UrlShortenerServiceIntegrationSpec extends IntegrationSpec {
 


### PR DESCRIPTION
Here's what I did:

- Upgraded project to Grails 2.4.4
- Added ShortenerTagLib with link and createLink tags
- Added documentation for the new tags
- Added sensible default for characters and minLength if not specified in Config.groovy
- The sequence generator bean is compatible with the sequence-generator plugin
- First I introduced a breaking change but then I found a way to not introduce a breaking change

I tried to create integration tests for the tag library but did not succeed. Seems Grails 2.4 makes this very hard.
The createLink tag has been in production for over a week now so I'm confident it works.

Sorry for many changes in one pull request. I can try to split them if you want.