### PR TITLE
Fixed a regression in 0.2 by adding back the default sequence generator

### DIFF
--- a/UrlShortenerGrailsPlugin.groovy
+++ b/UrlShortenerGrailsPlugin.groovy
@@ -42,5 +42,6 @@ This is a grails plugin that integrates a custom url shortener inside your Grail
         if (!shortenerConfig.shortDomain) {
             log.error "ERROR: UrlShortener short domain not found. The property shortener.shortDomain must be defined in Config.groovy"
         }
+        sequenceGenerator(net.kaleidos.shortener.generator.DummySequenceGenerator)
     }
 }

--- a/grails-app/conf/spring/resources.groovy
+++ b/grails-app/conf/spring/resources.groovy
@@ -1,3 +1,0 @@
-beans = {
-    sequenceGenerator(net.kaleidos.shortener.generator.DummySequenceGenerator)
-}


### PR DESCRIPTION
The default in-memory sequence generator is now added in the plugin descriptor doWithSpring. This is how it was implemented in version 0.1 of the plugin.
This makes the url shortener work out of the box. However the default generator should not be used in production deployments.